### PR TITLE
修复哔哩轻小说 reading 'innerText'

### DIFF
--- a/src/rules/twoPage/linovelib.ts
+++ b/src/rules/twoPage/linovelib.ts
@@ -20,7 +20,7 @@ export const linovelib = () => {
     getAuthor: () =>
       (
         document.querySelector(
-          ".book-meta > p:nth-child(2) > span:nth-child(1) > a:nth-child(2)"
+          ".book-meta > p:nth-child(2) > span:nth-child(1) > a:nth-child(1)"
         ) as HTMLElement
       ).innerText.trim(),
     getIntroDom: (doc) =>


### PR DESCRIPTION
修复Cannot read properties of null (reading 'innerText')导致的不能下载问题