### PR TITLE
修复 #427 问题，更新 gongzicp.ts 文件

### DIFF
--- a/src/rules/special/original/gongzicp.ts
+++ b/src/rules/special/original/gongzicp.ts
@@ -549,7 +549,7 @@ export class Gongzicp extends BaseRuleClass {
           resultI.data.chapterInfo.content.length < 30
         ) {
           retryTime++;
-          if (retryLimit > retryLimit) {
+          if (retryTime > retryLimit) {
             log.error(`请求 ${url} 失败`);
             throw new Error(`请求 ${url} 失败`);
           }
@@ -647,6 +647,7 @@ export class Gongzicp extends BaseRuleClass {
               chapterInfo.postscript,
             ].join("\n\n");
           }
+          await sleep(10000);
           return {
             chapterName,
             contentRaw,


### PR DESCRIPTION
#427  长佩修改了PC端页面访问机制，新的机制需要更久的时间间隔，并且似乎一个页面判定被盾后会保持被盾的状态，很长一段时间都恢复不了。修改后的代码仍可能会导致被屏蔽（但屏蔽状态不会持续，游走一会儿就好了，和原来一样），而下载速度为一分钟<6章。