### PR TITLE
fix 69shuba

### DIFF
--- a/src/header.json
+++ b/src/header.json
@@ -229,7 +229,7 @@
     "*://www.alphapolis.co.jp/novel/*/*",
     "*://novelup.plus/story/*",
     "*://69shuba.cx/book/*.htm",
-    "*://69shuba.com/book/*.htm",
+    "*://www.69shuba.com/book/*.htm",
     "*://book.xbookcn.net/search/label/*",
     "*://new-read.readmoo.com/mooreader/*",
     "*://www.iqingguo.com/book/detail/?id=*",

--- a/src/router/download.ts
+++ b/src/router/download.ts
@@ -562,7 +562,6 @@ export async function getRule(): Promise<BaseRuleClass> {
       ruleClass = xbookcn();
       break;
     }
-
     case "www.69yuedu.net": {
       const { c69yuedu } = await import("../rules/onePageWithMultiIndexPage/69yuedu");
       ruleClass = c69yuedu();

--- a/src/router/download.ts
+++ b/src/router/download.ts
@@ -551,6 +551,7 @@ export async function getRule(): Promise<BaseRuleClass> {
       ruleClass = xiaoshuowu();
       break;
     }
+    case "www.69shuba.com": 
     case "69shuba.cx": {
       const { c69shu } = await import("../rules/onePageWithMultiIndexPage/69shu");
       ruleClass = c69shu();
@@ -561,7 +562,7 @@ export async function getRule(): Promise<BaseRuleClass> {
       ruleClass = xbookcn();
       break;
     }
-    case "69shuba.com": 
+
     case "www.69yuedu.net": {
       const { c69yuedu } = await import("../rules/onePageWithMultiIndexPage/69yuedu");
       ruleClass = c69yuedu();

--- a/src/rules/onePageWithMultiIndexPage/69shu.ts
+++ b/src/rules/onePageWithMultiIndexPage/69shu.ts
@@ -18,7 +18,7 @@ export const c69shu = () =>
     getIndexPages: async () => {
       const indexPages: Document[] = [];
       const menuUrl = (
-        document.querySelector('a.btn.more-btn[href^="https://69shuba.cx/book/"]') as HTMLAnchorElement
+        document.querySelector('a.btn.more-btn[href^="https://69shuba.com/book/"]') as HTMLAnchorElement
       ).href;
       const doc = await getHtmlDOM(menuUrl, "GBK");
       indexPages.push(doc);

--- a/src/rules/onePageWithMultiIndexPage/69shu.ts
+++ b/src/rules/onePageWithMultiIndexPage/69shu.ts
@@ -18,7 +18,7 @@ export const c69shu = () =>
     getIndexPages: async () => {
       const indexPages: Document[] = [];
       const menuUrl = (
-        document.querySelector('a.btn.more-btn[href^="https://69shuba.com/book/"]') as HTMLAnchorElement
+        document.querySelector('a.btn.more-btn[href^="https://www.69shuba.com/book/"]') as HTMLAnchorElement
       ).href;
       const doc = await getHtmlDOM(menuUrl, "GBK");
       indexPages.push(doc);

--- a/src/rules/onePageWithMultiIndexPage/69shu.ts
+++ b/src/rules/onePageWithMultiIndexPage/69shu.ts
@@ -18,7 +18,7 @@ export const c69shu = () =>
     getIndexPages: async () => {
       const indexPages: Document[] = [];
       const menuUrl = (
-        document.querySelector('a.btn.more-btn[href^="https://www.69shuba.com/book/"]') as HTMLAnchorElement
+        document.querySelector('a.btn.more-btn[href]') as HTMLAnchorElement
       ).href;
       const doc = await getHtmlDOM(menuUrl, "GBK");
       indexPages.push(doc);


### PR DESCRIPTION
修复`www.69shuba.com`。
脚本已有的两个适配`69shuba.cx`、`69yuedu.net`的主站，目前两个网站均跳转到com站。
本次修复，脚本匹配域名缺少`www.`的问题。
com站可以复用cx镜像站的规则，但完整目录的匹配存在差异，主要是两个网站的网址部分，不确定cx站后续是否重启，修改网址不如删掉也不影响匹配。
经过测试可以在`www.69shuba.com`上使用，获取完整目录、正文也没有问题。