### PR TITLE
Fix for getIndexUrls return less than concurrency limit

### DIFF
--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -19,7 +19,10 @@ export function concurrencyRun(
   const { signal, reason } = options;
   const listCopy = [...list];
   const asyncList = [];
-  while (limit--) {
+  // Adjust limit to not exceed list length
+  const adjustedLimit = Math.min(limit, listCopy.length || 1);
+  
+  for (let i = 0; i < adjustedLimit; i++) {
     asyncList.push(recursion(listCopy));
   }
   return Promise.all(asyncList);
@@ -32,7 +35,11 @@ export function concurrencyRun(
         throw new ExpectError("concurrencyRun was aborted!");
       }
     }
-    await asyncHandle(arr.shift());
+    const item = arr.shift();
+    if (item === undefined) {
+      return "finish!";
+    }
+    await asyncHandle(item);
     if (arr.length !== 0) {
       return recursion(arr);
     } else {


### PR DESCRIPTION
When the chapter index url number is less than set concurrency limit, the ```concurrencyRun``` will fill ```recursion``` list with ```undefined``` element, causing it to error out.
Added checks for it.