### PR TITLE
biqugetw.ts 章节分页下载配置修复

### DIFF
--- a/src/rules/onePageWithMultiIndexPage/biqugetw.ts
+++ b/src/rules/onePageWithMultiIndexPage/biqugetw.ts
@@ -54,7 +54,7 @@ export const biqugetw = () =>
                   'div.read-page > a[rel="index"]',
                 ) as HTMLAnchorElement
               )?.href &&
-            !nextLink.includes("_") // paged chapter has "_<number>.html" in the URL
+            nextLink.includes("_") // paged chapter has "_<number>.html" in the URL
           );
         },
         enableCleanDOM: false,


### PR DESCRIPTION
修复 www.biquge.tw 章节内容分页仅下载第一页问题的错误配置