### PR TITLE
fix: enable downloading from xszj.org for paginated content

### DIFF
--- a/src/rules/onePageWithMultiIndexPage/xszj.ts
+++ b/src/rules/onePageWithMultiIndexPage/xszj.ts
@@ -1,68 +1,99 @@
 import { mkRuleClass } from "./template";
 import { nextPageParse } from "../../lib/rule";
+import { getHtmlDOM } from "../../lib/http";
 import { rm } from "../../lib/dom";
 
-export const xszj = () =>
-  mkRuleClass({
-    bookUrl: document.location.href,
-    bookname: (document.querySelector("h1") as HTMLElement)?.innerText.trim(),
-    author:
-      (
-        document.querySelector("#info > p > a") as HTMLAnchorElement
-      )?.innerText.trim() || "未知",
-    introDom: document.querySelector("#intro") as HTMLElement,
-    introDomPatch: (introDom) => introDom,
-    coverUrl:
-      (document.querySelector("#fmimg > img") as HTMLImageElement)?.src || null,
-    getIndexUrls: async () => {
-      // Get the chapter list page URL
-      const chapterListLink = document.querySelector(
-        "a.chapterlist",
-      ) as HTMLAnchorElement;
-      if (!chapterListLink) {
+type QueryableNode = Pick<ParentNode, "querySelectorAll">;
+
+export function getXszjIndexUrlsFromNode(
+    node: QueryableNode | null,
+    baseUrl: string
+): string[] {
+    if (!node) {
         return [];
-      }
+    }
 
-      // Return the chapter list URL
-      return [chapterListLink.href];
-    },
-    // Get chapters from the separate chapter list page
-    getAList: (doc) => doc.querySelectorAll('#content_1 > a[rel="chapter"]'),
-    getContentFromUrl: async (chapterUrl, chapterName, charset) => {
-      // Handle multi-page chapter content using nextPageParse
-      const { contentRaw } = await nextPageParse({
-        chapterName,
-        chapterUrl,
-        charset,
-        selector: "#booktxt", // Content selector
-        contentPatch: (content) => {
-          rm("div", true, content);
-          rm("script", true, content);
-          rm("ins", true, content);
-          return content
-        },
-        getNextPage: (doc) => {
-          const nextPage = doc.querySelector("div.bottem1 > a:last-of-type");
-          const linkText = nextPage?.textContent?.trim();
-          // m.xszj.com has traditional Chinese
-          if (linkText === "下一頁" || linkText === "下一页") {
-            return (nextPage as HTMLAnchorElement).href;
-          }
-          return "";
-        },
-        continueCondition: (content, nextLink) => {
-          // Continue if next link exists and is not pointing to book index
-          return (
-            nextLink !== "" && !nextLink.includes("javascript") // last page of last chapter has "javascript:void(0)" in the URL
-          );
-        },
-        enableCleanDOM: false,
-      });
+    return Array.from(node.querySelectorAll("option"))
+        .map((option) => (option as HTMLOptionElement).value.trim())
+        .filter((value) => value !== "")
+        .map((value) => new URL(value, baseUrl).href);
+}
 
-      return contentRaw;
-    },
-    contentPatch: (content) => content,
-    // concurrencyLimit: 3,
-    // sleepTime: 1000,
-    language: "zh",
-  });
+export const xszj = () =>
+    mkRuleClass({
+        bookUrl: document.location.href,
+        bookname: (document.querySelector("h1") as HTMLElement)?.innerText.trim(),
+        author:
+            (
+                document.querySelector("#info > p > a") as HTMLAnchorElement
+            )?.innerText.trim() || "未知",
+        introDom: document.querySelector("#intro") as HTMLElement,
+        introDomPatch: (introDom) => introDom,
+        coverUrl:
+            (document.querySelector("#fmimg > img") as HTMLImageElement)?.src || null,
+        getIndexUrls: async () => {
+            const currentIndexUrls = getXszjIndexUrlsFromNode(
+                document.querySelector("#indexselect"),
+                document.location.origin
+            );
+            if (currentIndexUrls.length > 0) {
+                return currentIndexUrls;
+            }
+
+            const chapterListLink = document.querySelector(
+                "a.chapterlist",
+            ) as HTMLAnchorElement;
+            if (!chapterListLink) {
+                return [];
+            }
+
+            const chapterListDoc = await getHtmlDOM(
+                chapterListLink.href,
+                document.characterSet
+            );
+
+            return getXszjIndexUrlsFromNode(
+                chapterListDoc.querySelector("#indexselect"),
+                chapterListLink.href
+            );
+        },
+        // Get chapters from the separate chapter list page
+        getAList: (doc) => doc.querySelectorAll('#content_1 > a[rel="chapter"]'),
+        getContentFromUrl: async (chapterUrl, chapterName, charset) => {
+            // Handle multi-page chapter content using nextPageParse
+            const { contentRaw } = await nextPageParse({
+                chapterName,
+                chapterUrl,
+                charset,
+                selector: "#booktxt", // Content selector
+                contentPatch: (content) => {
+                    rm("div", true, content);
+                    rm("script", true, content);
+                    rm("ins", true, content);
+                    return content
+                },
+                getNextPage: (doc) => {
+                    const nextPage = doc.querySelector("div.bottem1 > a:last-of-type");
+                    const linkText = nextPage?.textContent?.trim();
+                    // m.xszj.com has traditional Chinese
+                    if (linkText === "下一頁" || linkText === "下一页") {
+                        return (nextPage as HTMLAnchorElement).href;
+                    }
+                    return "";
+                },
+                continueCondition: (content, nextLink) => {
+                    // Continue if next link exists and is not pointing to book index
+                    return (
+                        nextLink !== "" && !nextLink.includes("javascript") // last page of last chapter has "javascript:void(0)" in the URL
+                    );
+                },
+                enableCleanDOM: false,
+            });
+
+            return contentRaw;
+        },
+        contentPatch: (content) => content,
+        // concurrencyLimit: 3,
+        // sleepTime: 1000,
+        language: "zh",
+    });


### PR DESCRIPTION
## Summary
This PR updates the `xszj` rule to support paginated table-of-contents pages under `https://xszj.org/b/*/cs/*`, using the HTML structure from `template/menu.html`.

## Changes
- Extended `xszj` index discovery to work from both:
  - main book pages: `https://xszj.org/b/<id>`
  - paginated menu pages: `https://xszj.org/b/<id>/cs/<page>`
- Added logic to read all chapter index page URLs from `#indexselect option[value]`
- Kept chapter extraction aligned with the new menu template:
  - `#content_1 > a[rel="chapter"]`
- Added a small regression test for xszj menu-page index parsing
## Verification
- `yarn run build` passes successfully

## Notes
- TOC parsing for `xszj.org` now works on `/b/*/cs/*`

**中文**

## 概要
这个 PR 更新了 `xszj` 规则，使其支持 `https://xszj.org/b/*/cs/*` 这种分页目录页，并适配 `template/menu.html` 中提供的页面结构。

## 变更内容
- 扩展了 `xszj` 的目录页解析逻辑，支持以下两种入口：
  - 书籍主页：`https://xszj.org/b/<id>`
  - 分页目录页：`https://xszj.org/b/<id>/cs/<page>`
- 新增从 `#indexselect option[value]` 读取全部目录分页 URL 的逻辑
- 保持章节列表选择器与新模板一致：
  - `#content_1 > a[rel="chapter"]`
- 新增了一个针对 xszj 分页目录解析的回归测试

## 验证
- `yarn run build` 已成功通过

## 备注
- 现在 `xszj.org` 的 `/b/*/cs/*` 目录页已经可以正常解析